### PR TITLE
Add new 'freeze time before 2am' option & fix manual unfreeze behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ on the wiki for help contributing translations.
 
 &nbsp;     | All Professions                  | Instant Grow Trees                 | Recatch Legendary Fish                 | TimeSpeed
 :--------- | :------------------------------- | :--------------------------------- | :------------------------------------- | :--------------------------
-Chinese    | [❑](AllProfessions/i18n)         | [❑](InstantGrowTrees/i18n)         | [✓](RecatchLegendaryFish/i18n/zh.json) | [✓](TimeSpeed/i18n/zh.json)
-French     | [❑](AllProfessions/i18n)         | [❑](InstantGrowTrees/i18n)         | [❑](RecatchLegendaryFish/i18n)         | [✓](TimeSpeed/i18n/fr.json)
-German     | [❑](AllProfessions/i18n)         | [❑](InstantGrowTrees/i18n)         | [❑](RecatchLegendaryFish/i18n)         | [✓](TimeSpeed/i18n/de.json)
+Chinese    | [❑](AllProfessions/i18n)         | [❑](InstantGrowTrees/i18n)         | [✓](RecatchLegendaryFish/i18n/zh.json) | [↻](TimeSpeed/i18n/zh.json)
+French     | [❑](AllProfessions/i18n)         | [❑](InstantGrowTrees/i18n)         | [❑](RecatchLegendaryFish/i18n)         | [↻](TimeSpeed/i18n/fr.json)
+German     | [❑](AllProfessions/i18n)         | [❑](InstantGrowTrees/i18n)         | [❑](RecatchLegendaryFish/i18n)         | [↻](TimeSpeed/i18n/de.json)
 Hungarian  | [✓](AllProfessions/i18n/hu.json) | [❑](InstantGrowTrees/i18n)         | [❑](RecatchLegendaryFish/i18n)         | [❑](TimeSpeed/i18n)
-Italian    | [❑](AllProfessions/i18n)         | [❑](InstantGrowTrees/i18n)         | [❑](RecatchLegendaryFish/i18n)         | [✓](TimeSpeed/i18n/it.json)
-Japanese   | [✓](AllProfessions/i18n/ja.json) | [❑](InstantGrowTrees/i18n)         | [❑](RecatchLegendaryFish/i18n)         | [✓](TimeSpeed/i18n/ja.json)
-Korean     | [❑](AllProfessions/i18n)         | [✓](InstantGrowTrees/i18n/ko.json) | [✓](RecatchLegendaryFish/i18n/ko.json) | [✓](TimeSpeed/i18n/ko.json)
-Portuguese | [✓](AllProfessions/i18n/pt.json) | [✓](InstantGrowTrees/i18n/pt.json) | [✓](RecatchLegendaryFish/i18n/pt.json) | [✓](TimeSpeed/i18n/pt.json)
-Russian    | [✓](AllProfessions/i18n/ru.json) | [❑](InstantGrowTrees/i18n)         | [❑](RecatchLegendaryFish/i18n)         | [✓](TimeSpeed/i18n/ru.json)
-Spanish    | [✓](AllProfessions/i18n/es.json) | [✓](InstantGrowTrees/i18n/es.json) | [✓](RecatchLegendaryFish/i18n/es.json) | [✓](TimeSpeed/i18n/es.json)
+Italian    | [❑](AllProfessions/i18n)         | [❑](InstantGrowTrees/i18n)         | [❑](RecatchLegendaryFish/i18n)         | [↻](TimeSpeed/i18n/it.json)
+Japanese   | [✓](AllProfessions/i18n/ja.json) | [❑](InstantGrowTrees/i18n)         | [❑](RecatchLegendaryFish/i18n)         | [↻](TimeSpeed/i18n/ja.json)
+Korean     | [❑](AllProfessions/i18n)         | [✓](InstantGrowTrees/i18n/ko.json) | [✓](RecatchLegendaryFish/i18n/ko.json) | [↻](TimeSpeed/i18n/ko.json)
+Portuguese | [✓](AllProfessions/i18n/pt.json) | [✓](InstantGrowTrees/i18n/pt.json) | [✓](RecatchLegendaryFish/i18n/pt.json) | [↻](TimeSpeed/i18n/pt.json)
+Russian    | [✓](AllProfessions/i18n/ru.json) | [❑](InstantGrowTrees/i18n)         | [❑](RecatchLegendaryFish/i18n)         | [↻](TimeSpeed/i18n/ru.json)
+Spanish    | [✓](AllProfessions/i18n/es.json) | [✓](InstantGrowTrees/i18n/es.json) | [✓](RecatchLegendaryFish/i18n/es.json) | [↻](TimeSpeed/i18n/es.json)
 Turkish    | [❑](AllProfessions/i18n)         | [❑](InstantGrowTrees/i18n)         | [❑](RecatchLegendaryFish/i18n)         | [❑](TimeSpeed/i18n)
 
 ## Compiling the mods

--- a/TimeSpeed/Framework/AutoFreezeReason.cs
+++ b/TimeSpeed/Framework/AutoFreezeReason.cs
@@ -1,5 +1,3 @@
-using StardewValley;
-
 namespace TimeSpeed.Framework;
 
 /// <summary>The reasons for automated time freezes.</summary>
@@ -8,12 +6,12 @@ internal enum AutoFreezeReason
     /// <summary>No freeze currently applies.</summary>
     None,
 
-    /// <summary>Time was automatically frozen based on the location per <see cref="ModConfig.ShouldFreeze(GameLocation)"/>.</summary>
+    /// <summary>Time was automatically frozen based on the location.</summary>
     FrozenForLocation,
 
-    /// <summary>Time was automatically frozen per <see cref="ModConfig.ShouldFreeze(int)"/>.</summary>
+    /// <summary>Time was automatically frozen based on the time of day.</summary>
     FrozenAtTime,
 
-    /// <summary>Time was automatically frozen per <see cref="ModConfig.ShouldFreezeBeforePassOut(int)"/>.</summary>
+    /// <summary>Time was automatically frozen before the player passed out.</summary>
     FrozenBeforePassOut
 }

--- a/TimeSpeed/Framework/AutoFreezeReason.cs
+++ b/TimeSpeed/Framework/AutoFreezeReason.cs
@@ -12,5 +12,8 @@ internal enum AutoFreezeReason
     FrozenForLocation,
 
     /// <summary>Time was automatically frozen per <see cref="ModConfig.ShouldFreeze(int)"/>.</summary>
-    FrozenAtTime
+    FrozenAtTime,
+
+    /// <summary>Time was automatically frozen per <see cref="ModConfig.ShouldFreezeBeforePassOut(int)"/>.</summary>
+    FrozenBeforePassOut
 }

--- a/TimeSpeed/Framework/GenericModConfigMenuIntegration.cs
+++ b/TimeSpeed/Framework/GenericModConfigMenuIntegration.cs
@@ -113,6 +113,13 @@ internal static class GenericModConfigMenuIntegration
         );
         api.AddBoolOption(
             manifest,
+            name: I18n.Config_FreezeBeforePassingOut_Name,
+            tooltip: I18n.Config_FreezeBeforePassingOut_Desc,
+            getValue: () => getConfig().FreezeTime.PassOut,
+            setValue: value => getConfig().FreezeTime.PassOut = value
+        );
+        api.AddBoolOption(
+            manifest,
             name: I18n.Config_FreezeTimeIndoors_Name,
             tooltip: I18n.Config_FreezeTimeIndoors_Desc,
             getValue: () => getConfig().FreezeTime.Indoors,

--- a/TimeSpeed/Framework/GenericModConfigMenuIntegration.cs
+++ b/TimeSpeed/Framework/GenericModConfigMenuIntegration.cs
@@ -114,7 +114,7 @@ internal static class GenericModConfigMenuIntegration
         api.AddBoolOption(
             manifest,
             name: I18n.Config_FreezeBeforePassingOut_Name,
-            tooltip: I18n.Config_FreezeBeforePassingOut_Desc,
+            tooltip: () => I18n.Config_FreezeBeforePassingOut_Desc(freezeTimeAt: I18n.Config_AnywhereAtTime_Name()),
             getValue: () => getConfig().FreezeTime.PassOut,
             setValue: value => getConfig().FreezeTime.PassOut = value
         );

--- a/TimeSpeed/Framework/ModConfig.cs
+++ b/TimeSpeed/Framework/ModConfig.cs
@@ -35,15 +35,18 @@ internal class ModConfig
         return this.FreezeTime.ShouldFreeze(location);
     }
 
-    /// <summary>Get whether the time should be frozen at a given time of day.</summary>
+    /// <summary>Get whether the time should be frozen at a given time of day based on the <see cref="ModFreezeTimeConfig.AnywhereAtTime"/> option.</summary>
     /// <param name="time">The time of day in 24-hour military format (e.g. 1600 for 8pm).</param>
-    /// <param name="passOutCheck">Get whether the time should be frozen before players pass out (1:50am).</param>
-    public bool ShouldFreeze(int time, bool passOutCheck = false)
+    public bool ShouldFreeze(int time)
     {
-        if(passOutCheck)
-            return time >= 2550 && this.FreezeTime.PassOut;
-        else
-            return time >= this.FreezeTime.AnywhereAtTime;
+        return time >= this.FreezeTime.AnywhereAtTime;
+    }
+
+    /// <summary>Get whether the time should be frozen at a given time of day based on the <see cref="ModFreezeTimeConfig.PassOut"/> option.</summary>
+    /// <param name="time">The time of day in 24-hour military format (e.g. 1600 for 8pm).</param>
+    public bool ShouldFreezeBeforePassingOut(int time)
+    {
+        return time >= 2550 && this.FreezeTime.PassOut;
     }
 
     /// <summary>Get whether time settings should be applied on a given day.</summary>

--- a/TimeSpeed/Framework/ModConfig.cs
+++ b/TimeSpeed/Framework/ModConfig.cs
@@ -37,9 +37,13 @@ internal class ModConfig
 
     /// <summary>Get whether the time should be frozen at a given time of day.</summary>
     /// <param name="time">The time of day in 24-hour military format (e.g. 1600 for 8pm).</param>
-    public bool ShouldFreeze(int time)
+    /// <param name="passOutCheck">Get whether the time should be frozen before players pass out (1:50am).</param>
+    public bool ShouldFreeze(int time, bool passOutCheck = false)
     {
-        return time >= this.FreezeTime.AnywhereAtTime;
+        if(passOutCheck)
+            return time >= 2550 && this.FreezeTime.PassOut;
+        else
+            return time >= this.FreezeTime.AnywhereAtTime;
     }
 
     /// <summary>Get whether time settings should be applied on a given day.</summary>

--- a/TimeSpeed/Framework/ModFreezeTimeConfig.cs
+++ b/TimeSpeed/Framework/ModFreezeTimeConfig.cs
@@ -15,6 +15,9 @@ internal class ModFreezeTimeConfig
     /// <summary>The time at which to freeze time everywhere (or <c>null</c> to disable this). This should be 24-hour military time (e.g. 800 for 8am, 1600 for 8pm, etc).</summary>
     public int? AnywhereAtTime { get; set; }
 
+    /// <summary>Whether to freeze time before players pass out (1:50am).</summary>
+    public bool PassOut { get; set; } = false;
+
     /// <summary>Whether to freeze time indoors.</summary>
     public bool Indoors { get; set; } = false;
 

--- a/TimeSpeed/Framework/ModFreezeTimeConfig.cs
+++ b/TimeSpeed/Framework/ModFreezeTimeConfig.cs
@@ -15,7 +15,7 @@ internal class ModFreezeTimeConfig
     /// <summary>The time at which to freeze time everywhere (or <c>null</c> to disable this). This should be 24-hour military time (e.g. 800 for 8am, 1600 for 8pm, etc).</summary>
     public int? AnywhereAtTime { get; set; }
 
-    /// <summary>Whether to freeze time before players pass out (1:50am).</summary>
+    /// <summary>Whether to freeze time before the player passes out (i.e. at 1:50am).</summary>
     public bool PassOut { get; set; } = false;
 
     /// <summary>Whether to freeze time indoors.</summary>

--- a/TimeSpeed/ModEntry.cs
+++ b/TimeSpeed/ModEntry.cs
@@ -342,15 +342,12 @@ internal class ModEntry : Mod
             switch (this.AutoFreeze)
             {
                 case AutoFreezeReason.FrozenAtTime when this.IsTimeFrozen:
+                case AutoFreezeReason.FrozenBeforePassOut when this.IsTimeFrozen:
                     this.Notifier.ShortNotify(I18n.Message_OnLocationChange_TimeStoppedGlobally());
                     break;
 
                 case AutoFreezeReason.FrozenForLocation when this.IsTimeFrozen:
                     this.Notifier.ShortNotify(I18n.Message_OnLocationChange_TimeStoppedHere());
-                    break;
-
-                case AutoFreezeReason.FrozenBeforePassOut when this.IsTimeFrozen:
-                    this.Notifier.ShortNotify(I18n.Message_OnLocationChange_TimeStoppedGloballyPassOut());
                     break;
 
                 default:

--- a/TimeSpeed/ModEntry.cs
+++ b/TimeSpeed/ModEntry.cs
@@ -190,9 +190,9 @@ internal class ModEntry : Mod
         if (e.IsOneSecond && this.Monitor.IsVerbose)
         {
             string timeFrozenLabel;
-            if (this.ManualFreeze is true)
+            if (this.ManualFreeze)
                 timeFrozenLabel = ", frozen manually";
-            else if (this.ManualFreeze is false)
+            else if (this.SuspendAutoFreezes.Contains(this.AutoFreeze))
                 timeFrozenLabel = ", resumed manually";
             else if (this.IsTimeFrozen)
                 timeFrozenLabel = $", frozen per {this.AutoFreeze}";

--- a/TimeSpeed/i18n/de.json
+++ b/TimeSpeed/i18n/de.json
@@ -44,6 +44,8 @@
     "config.freeze-time": "Zeit Einfrier Optionen",
     "config.anywhere-at-time.name": "Zeit einfrieren bei",
     "config.anywhere-at-time.desc": "Die Zeit, zu der die Zeit überall eingefroren werden soll. (6 Uhr morgens) 600 bis 2400 (Mitternacht) und 2600 (2 Uhr morgens). Du kannst es auf 2600 einstellen, um es zu deaktivieren.",
+    "config.freeze-before-passing-out.name": "Freeze time before 2am", // TODO
+    "config.freeze-before-passing-out.desc": "Whether to freeze time everywhere before players pass out (i.e. at 1:50am). This is in addition to the '{{freezeTimeAt}}' option.", // TODO
     "config.freeze-time-indoors.name": "Drinnen",
     "config.freeze-time-indoors.desc": "Ob die Zeit in Häusern eingefroren werden soll.",
     "config.freeze-time-outdoors.name": "Draussen",

--- a/TimeSpeed/i18n/default.json
+++ b/TimeSpeed/i18n/default.json
@@ -13,6 +13,7 @@
 
     // changed based on location
     "message.on-location-change.time-stopped-globally": "Looks like time stopped everywhere...",
+    "message.on-location-change.time-stopped-globally-pass-out": "Time stopped, am I dreaming?",
     "message.on-location-change.time-stopped-here": "It feels like time is frozen here...",
     "message.on-location-change.time-speed-here": "10 minutes feels more like {{seconds}} seconds here...",
 
@@ -44,6 +45,8 @@
     "config.freeze-time": "Freeze time",
     "config.anywhere-at-time.name": "Freeze time at",
     "config.anywhere-at-time.desc": "The time at which to freeze time everywhere. This should be 24-hour military time, from 600 (6am) to 2400 (midnight) and 2600 (2am). You can set it to 2600 to disable it.",
+    "config.freeze-before-passing-out.name": "Freeze time before 2am",
+    "config.freeze-before-passing-out.desc": "Whether to freeze time everywhere at 1:50am, before players pass out. This functions in addition to the freeze time set above.",
     "config.freeze-time-indoors.name": "Indoors",
     "config.freeze-time-indoors.desc": "Whether to freeze time while indoors.",
     "config.freeze-time-outdoors.name": "Outdoors",

--- a/TimeSpeed/i18n/default.json
+++ b/TimeSpeed/i18n/default.json
@@ -45,7 +45,7 @@
     "config.anywhere-at-time.name": "Freeze time at",
     "config.anywhere-at-time.desc": "The time at which to freeze time everywhere. This should be 24-hour military time, from 600 (6am) to 2400 (midnight) and 2600 (2am). You can set it to 2600 to disable it.",
     "config.freeze-before-passing-out.name": "Freeze time before 2am",
-    "config.freeze-before-passing-out.desc": "Whether to freeze time everywhere at 1:50am, before players pass out. This functions in addition to the freeze time set above.",
+    "config.freeze-before-passing-out.desc": "Whether to freeze time everywhere before players pass out (i.e. at 1:50am). This is in addition to the '{{freezeTimeAt}}' option.",
     "config.freeze-time-indoors.name": "Indoors",
     "config.freeze-time-indoors.desc": "Whether to freeze time while indoors.",
     "config.freeze-time-outdoors.name": "Outdoors",

--- a/TimeSpeed/i18n/default.json
+++ b/TimeSpeed/i18n/default.json
@@ -13,7 +13,6 @@
 
     // changed based on location
     "message.on-location-change.time-stopped-globally": "Looks like time stopped everywhere...",
-    "message.on-location-change.time-stopped-globally-pass-out": "Time stopped, am I dreaming?",
     "message.on-location-change.time-stopped-here": "It feels like time is frozen here...",
     "message.on-location-change.time-speed-here": "10 minutes feels more like {{seconds}} seconds here...",
 

--- a/TimeSpeed/i18n/es.json
+++ b/TimeSpeed/i18n/es.json
@@ -44,6 +44,8 @@
     "config.freeze-time": "Tiempo de congelación",
     "config.anywhere-at-time.name": "Tiempo de congelación en",
     "config.anywhere-at-time.desc": "La hora a la que se debe congelar el tiempo en todas partes. Debe ser la hora militar de 24 horas, desde las 600 (6am) hasta las 2400 (medianoche) y 2600 (2am). Puedes ponerlo en 2600 para desactivarlo.",
+    "config.freeze-before-passing-out.name": "Freeze time before 2am", // TODO
+    "config.freeze-before-passing-out.desc": "Whether to freeze time everywhere before players pass out (i.e. at 1:50am). This is in addition to the '{{freezeTimeAt}}' option.", // TODO
     "config.freeze-time-indoors.name": "En interiores",
     "config.freeze-time-indoors.desc": "Si congelar el tiempo en el interior.",
     "config.freeze-time-outdoors.name": "En exteriores",

--- a/TimeSpeed/i18n/fr.json
+++ b/TimeSpeed/i18n/fr.json
@@ -44,6 +44,8 @@
     "config.freeze-time": "Figer le temps",
     "config.anywhere-at-time.name": "Figer le temps à",
     "config.anywhere-at-time.desc": "L'heure à laquelle le temps sera figé partout. Exprimé en temps militaire au format 24 heures, de 600 (6h00) à 2400 (minuit) et 2600 (2h00). Assigner à 2600 pour désactiver.",
+    "config.freeze-before-passing-out.name": "Freeze time before 2am", // TODO
+    "config.freeze-before-passing-out.desc": "Whether to freeze time everywhere before players pass out (i.e. at 1:50am). This is in addition to the '{{freezeTimeAt}}' option.", // TODO
     "config.freeze-time-indoors.name": "À l'intérieur",
     "config.freeze-time-indoors.desc": "S'il faut figer le temps à l'intérieur.",
     "config.freeze-time-outdoors.name": "À l'extérieur",

--- a/TimeSpeed/i18n/it.json
+++ b/TimeSpeed/i18n/it.json
@@ -44,6 +44,8 @@
     "config.freeze-time": "Tempo congelato",
     "config.anywhere-at-time.name": "Tempo congelato a",
     "config.anywhere-at-time.desc": "Il tempo in cui congelare il tempo ovunque. Dovrebbe essere l'ora militare di 24 ore, da 600 (6 del mattino) a 2400 (mezzanotte) e 2600 (2 del mattino). È possibile impostarlo a 2600 per disabilitarlo. ",
+    "config.freeze-before-passing-out.name": "Freeze time before 2am", // TODO
+    "config.freeze-before-passing-out.desc": "Whether to freeze time everywhere before players pass out (i.e. at 1:50am). This is in addition to the '{{freezeTimeAt}}' option.", // TODO
     "config.freeze-time-indoors.name": "Negli interni",
     "config.freeze-time-indoors.desc": "Per congelare il tempo negli interni",
     "config.freeze-time-outdoors.name": "Negli esterni",

--- a/TimeSpeed/i18n/ja.json
+++ b/TimeSpeed/i18n/ja.json
@@ -44,6 +44,8 @@
     "config.freeze-time": "時間の停止",
     "config.anywhere-at-time.name": "停止する時刻",
     "config.anywhere-at-time.desc": "あらゆる場所で時間を止める時刻。600(午前6時)から2400(午前0時)、2600(午前2時)までの24時間のミリタリータイムでなければならない。2600に設定すると無効になる。",
+    "config.freeze-before-passing-out.name": "Freeze time before 2am", // TODO
+    "config.freeze-before-passing-out.desc": "Whether to freeze time everywhere before players pass out (i.e. at 1:50am). This is in addition to the '{{freezeTimeAt}}' option.", // TODO
     "config.freeze-time-indoors.name": "屋内",
     "config.freeze-time-indoors.desc": "屋内で時間を止めるかどうか。",
     "config.freeze-time-outdoors.name": "屋外",

--- a/TimeSpeed/i18n/ko.json
+++ b/TimeSpeed/i18n/ko.json
@@ -44,6 +44,8 @@
     "config.freeze-time": "정지 시간",
     "config.anywhere-at-time.name": "시간 고정",
     "config.anywhere-at-time.desc": "모든 곳에서 시간을 고정할 시간입니다. 이것은 600(오전 6시)에서 2400(자정) 및 2600(오전 2시)까지의 24시간 군사 시간이어야 합니다. 다음을 설정할 수 있습니다. 비활성화하려면 2600으로 설정하십시오.",
+    "config.freeze-before-passing-out.name": "Freeze time before 2am", // TODO
+    "config.freeze-before-passing-out.desc": "Whether to freeze time everywhere before players pass out (i.e. at 1:50am). This is in addition to the '{{freezeTimeAt}}' option.", // TODO
     "config.freeze-time-indoors.name": "실내",
     "config.freeze-time-indoors.desc": "실내에서 시간을 정지할지 여부.",
     "config.freeze-time-outdoors.name": "야외",

--- a/TimeSpeed/i18n/pt.json
+++ b/TimeSpeed/i18n/pt.json
@@ -44,6 +44,8 @@
     "config.freeze-time": "Congelar tempo",
     "config.anywhere-at-time.name": "Congelar tempo em",
     "config.anywhere-at-time.desc": "A hora para congelar o tempo em todos os lugares. Deve ser o horário militar de 24 horas, das 600 (6h) às 2400 (meia-noite) e 2600 (2h). Você pode configurá-lo para 2600 para desativá-lo.",
+    "config.freeze-before-passing-out.name": "Freeze time before 2am", // TODO
+    "config.freeze-before-passing-out.desc": "Whether to freeze time everywhere before players pass out (i.e. at 1:50am). This is in addition to the '{{freezeTimeAt}}' option.", // TODO
     "config.freeze-time-indoors.name": "Ambientes fechados",
     "config.freeze-time-indoors.desc": "Seja para congelar o tempo em ambientes fechados.",
     "config.freeze-time-outdoors.name": "Ambientes abertos",

--- a/TimeSpeed/i18n/ru.json
+++ b/TimeSpeed/i18n/ru.json
@@ -44,6 +44,8 @@
     "config.freeze-time": "Остановка времени",
     "config.anywhere-at-time.name": "Останавливать время в",
     "config.anywhere-at-time.desc": "Момент времени, когда оно полностью остановится. 600 - 6:00 (6 утра), 2400 - 00:00 (полночь) и 2600 (2 часа ночи). Если установить значение 2600, эта опция будет отключена.",
+    "config.freeze-before-passing-out.name": "Freeze time before 2am", // TODO
+    "config.freeze-before-passing-out.desc": "Whether to freeze time everywhere before players pass out (i.e. at 1:50am). This is in addition to the '{{freezeTimeAt}}' option.", // TODO
     "config.freeze-time-indoors.name": "В помещениях",
     "config.freeze-time-indoors.desc": "Эта опция полностью остановит время внитри помещений.",
     "config.freeze-time-outdoors.name": "На улице",

--- a/TimeSpeed/i18n/zh.json
+++ b/TimeSpeed/i18n/zh.json
@@ -44,6 +44,8 @@
     "config.freeze-time": "冻结时间",
     "config.anywhere-at-time.name": "什么时候冻结",
     "config.anywhere-at-time.desc": "设置自动冻结全地图时间的时间节点，600表示早上6点，2400表示凌晨2点，默认2400，表示禁用。",
+    "config.freeze-before-passing-out.name": "Freeze time before 2am", // TODO
+    "config.freeze-before-passing-out.desc": "Whether to freeze time everywhere before players pass out (i.e. at 1:50am). This is in addition to the '{{freezeTimeAt}}' option.", // TODO
     "config.freeze-time-indoors.name": "建筑内",
     "config.freeze-time-indoors.desc": "建筑内时是否冻结时间",
     "config.freeze-time-outdoors.name": "室外",


### PR DESCRIPTION
There is now an additional option in the menu to freeze time before passing out at 1:50am. This option is in addition to the autofreeze at specific time. Resolves #35.

I also added individual override flags to each auto-freeze-reason, which coincidentally was also a bugfix!
- Before, if time was autofrozen because of a specific time trigger, the player could manually unfreeze to override. This would, however, **also** override location freezes, so all location-specific freezes would be unintentionally unfrozen; e.g., when going from an unfrozen to an intended frozen location.
- Now, because of the individual override flags, manually unfreezing locations will get their override flag cleared when players warp to a new location, and time-specific autofreezes clear on a new day.
- This fix allows for multiple freezes in a day, even when overriding some.